### PR TITLE
Add the ability to skip unpacking the initial file system

### DIFF
--- a/.github/workflows/images.yaml
+++ b/.github/workflows/images.yaml
@@ -91,9 +91,9 @@ jobs:
 
     # Sign images if not a PR.
     - if: github.event_name != 'pull_request'
-      uses: sigstore/cosign-installer@d6a3abf1bdea83574e28d40543793018b6035605
+      uses: sigstore/cosign-installer@b3413d484cc23cf8778c3d2aa361568d4eb54679 # v2.5.1
       with:
-        cosign-release: 'v1.4.1'
+        cosign-release: 'v1.11.1'
     - if: github.event_name != 'pull_request'
       env:
         COSIGN_EXPERIMENTAL: "true"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
 - fix: Refactor LayersMap to correct old strange code behavior [#2066](https://github.com/GoogleContainerTools/kaniko/pull/2066)
 - Fix missing setuid flags on COPY --from=build operation [#2089](https://github.com/GoogleContainerTools/kaniko/pull/2089)
 - Fixes #2046: make target stage lookup case insensitive [#2047](https://github.com/GoogleContainerTools/kaniko/pull/2047)
-- Add GitLab CI credentials helper [#2040]((https://github.com/GoogleContainerTools/kaniko/pull/2040))
+- Add GitLab CI credentials helper [#2040](https://github.com/GoogleContainerTools/kaniko/pull/2040)
 - and a number of dependency bumps
 
 

--- a/README.md
+++ b/README.md
@@ -480,12 +480,6 @@ cache for the layer. If it exists, kaniko will pull and extract the cached layer
 instead of executing the command. If not, kaniko will execute the command and
 then push the newly created layer to the cache.
 
-kaniko can cache layers created by `RUN` (and `COPY`, configured by the
-`--cache-copy-layers` flag) commands in a remote repository. Before executing a
-command, kaniko checks the cache for the layer. If it exists, kaniko will pull
-and extract the cached layer instead of executing the command. If not, kaniko
-will execute the command and then push the newly created layer to the cache.
-
 Note that kaniko cannot read layers from the cache after a cache miss: once a
 layer has not been found in the cache, all subsequent layers are built locally
 without consulting the cache.

--- a/pkg/config/options.go
+++ b/pkg/config/options.go
@@ -82,6 +82,7 @@ type KanikoOptions struct {
 	CacheCopyLayers          bool
 	CacheRunLayers           bool
 	ForceBuildMetadata       bool
+	InitialFSUnpacked        bool
 }
 
 type KanikoGitOptions struct {

--- a/pkg/dockerfile/dockerfile.go
+++ b/pkg/dockerfile/dockerfile.go
@@ -58,6 +58,10 @@ func ParseStages(opts *config.KanikoOptions) ([]instructions.Stage, []instructio
 		return nil, nil, errors.Wrap(err, "parsing dockerfile")
 	}
 
+	if opts.CacheCopyLayers && len(stages) >= 2 {
+		return nil, nil, errors.New("kaniko does not support caching copy layers in multistage builds")
+	}
+
 	metaArgs, err = expandNested(metaArgs, opts.BuildArgs)
 	if err != nil {
 		return nil, nil, errors.Wrap(err, "expanding meta ARGs")

--- a/pkg/dockerfile/dockerfile_test.go
+++ b/pkg/dockerfile/dockerfile_test.go
@@ -29,6 +29,39 @@ import (
 	"github.com/moby/buildkit/frontend/dockerfile/instructions"
 )
 
+func Test_ParseStages_NoMultistageWithCacheCopy(t *testing.T) {
+	dockerfile := `
+	FROM scratch as first
+	COPY testfile /
+
+	FROM scratch as second
+	COPY --from=second testfile /
+	`
+	tmpfile, err := ioutil.TempFile("", "Dockerfile.test")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	defer os.Remove(tmpfile.Name())
+
+	if _, err := tmpfile.Write([]byte(dockerfile)); err != nil {
+		t.Fatal(err)
+	}
+	if err := tmpfile.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	opts := &config.KanikoOptions{
+		DockerfilePath:  tmpfile.Name(),
+		CacheCopyLayers: true,
+	}
+
+	_, _, err = ParseStages(opts)
+	if err == nil {
+		t.Fatal("expected ParseStages to fail on MultiStage build if CacheCopyLayers=true")
+	}
+}
+
 func Test_ParseStages_ArgValueWithQuotes(t *testing.T) {
 	dockerfile := `
 	ARG IMAGE="ubuntu:16.04"

--- a/pkg/executor/build.go
+++ b/pkg/executor/build.go
@@ -55,6 +55,7 @@ const emptyTarSize = 1024
 // for testing
 var (
 	initializeConfig = initConfig
+	getFSFromImage   = util.GetFSFromImage
 )
 
 type cachePusher func(*config.KanikoOptions, string, string, string) error
@@ -322,12 +323,15 @@ func (s *stageBuilder) build() error {
 	if len(s.crossStageDeps[s.stage.Index]) > 0 {
 		shouldUnpack = true
 	}
+	if s.stage.Index == 0 && s.opts.InitialFSUnpacked {
+		shouldUnpack = false
+	}
 
 	if shouldUnpack {
 		t := timing.Start("FS Unpacking")
 
 		retryFunc := func() error {
-			_, err := util.GetFSFromImage(config.RootDir, s.image, util.ExtractFile)
+			_, err := getFSFromImage(config.RootDir, s.image, util.ExtractFile)
 			return err
 		}
 
@@ -622,7 +626,6 @@ func DoBuild(opts *config.KanikoOptions) (v1.Image, error) {
 	var args *dockerfile.BuildArgs
 
 	for index, stage := range kanikoStages {
-
 		sb, err := newStageBuilder(
 			args, opts, stage,
 			crossStageDependencies,

--- a/pkg/filesystem/resolve.go
+++ b/pkg/filesystem/resolve.go
@@ -120,7 +120,7 @@ func filesWithParentDirs(files []string) []string {
 }
 
 // resolveSymlinkAncestor returns the ancestor link of the provided symlink path or returns the
-// the path if it is not a link. The ancestor link is the filenode whose type is a Symlink.
+// path if it is not a link. The ancestor link is the filenode whose type is a Symlink.
 // E.G /baz/boom/bar.txt links to /usr/bin/bar.txt but /baz/boom/bar.txt itself is not a link.
 // Instead /bar/boom is actually a link to /usr/bin. In this case resolveSymlinkAncestor would
 // return /bar/boom.
@@ -147,7 +147,7 @@ loop:
 			// one of its ancestors could be a symlink. We call filepath.EvalSymlinks
 			// to test whether there are any links in the path. If the output of
 			// EvalSymlinks is different than the input we know one of the nodes in the
-			// the path is a link.
+			// path is a link.
 			target, err := filepath.EvalSymlinks(newPath)
 			if err != nil {
 				return "", err

--- a/pkg/util/tar_util.go
+++ b/pkg/util/tar_util.go
@@ -149,7 +149,7 @@ const (
 )
 
 // writeSecurityXattrToTarHeader writes security.capability
-// xattrs from a a tar header to filesystem
+// xattrs from a tar header to filesystem
 func writeSecurityXattrToToFile(path string, hdr *tar.Header) error {
 	if hdr.Xattrs == nil {
 		return nil
@@ -253,7 +253,7 @@ func UnpackLocalTarArchive(path, dest string) ([]string, error) {
 	return nil, errors.New("path does not lead to local tar archive")
 }
 
-//IsFileLocalTarArchive returns true if the file is a local tar archive
+// IsFileLocalTarArchive returns true if the file is a local tar archive
 func IsFileLocalTarArchive(src string) bool {
 	compressed, _ := fileIsCompressedTar(src)
 	uncompressed := fileIsUncompressedTar(src)


### PR DESCRIPTION


<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

**Description**

Add the ability to skip unpacking the initial file system
- Adds a new option, InitialFSUnpacked
- When opts.InitialFSUnpacked is true, the first stage builder will
  skip unpacking the file system; later stages are unaffected

Why do this:
This only makes sense if kaniko is used as a library, and the executor is running
in the context of an image that is the image referenced in the first `FROM` statement
in the Dockerfile. buildpacks.io is aiming to do this in order to customize base images
prior to buildpacks builds. 

**Submitter Checklist**

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [unit tests](../DEVELOPMENT.md#creating-a-pr)
- [ ] Adds integration tests if needed.

_See [the contribution guide](../CONTRIBUTING.md) for more details._


**Reviewer Notes**

- [ ] The code flow looks good. 
- [ ] Unit tests and or integration tests added.


**Release Notes**

Describe any changes here so maintainer can include it in the release notes, or delete this block.

```
Examples of user facing changes:
- kaniko adds a new flag `--registry-repo` to override registry

```
